### PR TITLE
Add Gleam language support with LSP and formatting

### DIFF
--- a/nix/flake/checks.nix
+++ b/nix/flake/checks.nix
@@ -123,6 +123,13 @@
           extraPath = [ pkgs.go ];
         };
 
+        "lsp-integration-gleam-gleam" = runIntegrationTest {
+          name = "lsp-integration-gleam-gleam";
+          fixture = "gleam/basic";
+          openFile = "src/main.gleam";
+          spec = "lsp_gleam.lua";
+        };
+
         "lsp-integration-typescript-ts-ls" = runIntegrationTest {
           name = "lsp-integration-typescript-ts-ls";
           fixture = "typescript/basic";

--- a/nix/runtimeDeps.nix
+++ b/nix/runtimeDeps.nix
@@ -98,6 +98,9 @@ with pkgs;
   ### Go ###
   gopls
 
+  ### Gleam ###
+  gleam
+
   ### Elixir ###
   elixir
   elixir-ls

--- a/nvim/lua/config/plugins/conform.lua
+++ b/nvim/lua/config/plugins/conform.lua
@@ -21,6 +21,7 @@ conform.setup({
     elixir = { "mix_format" },
     eelixir = { "mix_format" },
     heex = { "mix_format" },
+    gleam = { "gleam_format" },
     javascript = { "prettier" },
     javascriptreact = { "prettier" },
     typescript = { "prettier" },
@@ -83,6 +84,13 @@ conform.setup({
         ".formatter.exs",
       }),
       require_cwd = true,
+    },
+    gleam_format = {
+      command = "gleam",
+      args = { "format", "--stdin" },
+      cwd = require("conform.util").root_file({
+        "gleam.toml",
+      }),
     },
   },
 })

--- a/nvim/lua/config/plugins/lsp/servers.lua
+++ b/nvim/lua/config/plugins/lsp/servers.lua
@@ -132,6 +132,9 @@ local servers = {
   --- https://github.com/neovim/nvim-lspconfig/blob/master/lsp/elixirls.lua
   elixirls = {},
 
+  --- https://github.com/neovim/nvim-lspconfig/blob/master/lsp/gleam.lua
+  gleam = {},
+
   --- https://github.com/neovim/nvim-lspconfig/blob/master/lsp/gopls.lua
   gopls = {
     settings = {

--- a/nvim/tests/integration/fixtures/gleam/basic/gleam.toml
+++ b/nvim/tests/integration/fixtures/gleam/basic/gleam.toml
@@ -1,0 +1,2 @@
+name = "basic"
+version = "1.0.0"

--- a/nvim/tests/integration/fixtures/gleam/basic/src/main.gleam
+++ b/nvim/tests/integration/fixtures/gleam/basic/src/main.gleam
@@ -1,0 +1,9 @@
+import gleam/io
+
+fn greet() {
+  "Hello"
+}
+
+pub fn main() {
+  io.println(greet())
+}

--- a/nvim/tests/integration/lsp_gleam.lua
+++ b/nvim/tests/integration/lsp_gleam.lua
@@ -1,0 +1,33 @@
+-- luacheck: globals describe it assert
+
+local bootstrap = require("integration_test.bootstrap")
+local runner = require("integration_test.lsp_runner")
+
+runner.define({
+  describe = "Gleam integration test",
+  it = "attaches and resolves local definitions",
+  client_name = "gleam",
+  timeout_ms = 30000,
+  request_timeout_ms = 2000,
+  probes = {
+    {
+      type = "attach",
+      assert = function(client)
+        assert.are.equal("gleam", client.name)
+      end,
+    },
+    {
+      type = "definition",
+      path_suffix = "src/main.gleam",
+      prepare = function(context)
+        bootstrap.set_cursor(context.bufnr, "greet()")
+      end,
+      assert = function(definition, context)
+        local uri = definition.targetUri or definition.uri
+
+        assert.is_truthy(uri)
+        assert.is_truthy(vim.uri_to_fname(uri):find(context.workspace_root, 1, true))
+      end,
+    },
+  },
+})


### PR DESCRIPTION
Adds comprehensive Gleam language support to the Neovim configuration:

## Changes
- **LSP Server**: Configure gleam LSP server in lsp/servers.lua
- **Code Formatting**: Add gleam_format formatter to conform.lua with gleam.toml root detection
- **Runtime Dependencies**: Add gleam package to nix/runtimeDeps.nix
- **Test Fixtures**: Create basic Gleam project fixture with simple module
- **Integration Tests**: Add lsp_gleam.lua test verifying LSP attachment and definition resolution
- **CI Configuration**: Register gleam LSP integration test in checks.nix

The implementation follows existing patterns for other language servers and includes full integration testing.