### PR TITLE
Add TreeSitter highlights for diff files

### DIFF
--- a/nvim/queries/diff/highlights.scm
+++ b/nvim/queries/diff/highlights.scm
@@ -1,0 +1,49 @@
+(comment) @comment @spell
+
+[
+  (addition)
+  (new_file)
+] @diff.plus
+
+[
+  (deletion)
+  (old_file)
+] @diff.minus
+
+(commit) @constant
+
+(location) @attribute
+
+(command
+  "diff" @function
+  (argument) @variable.parameter)
+
+(filename) @string.special.path
+
+(mode) @number
+
+([
+  ".."
+  "+"
+  "++"
+  "+++"
+  "++++"
+  "-"
+  "--"
+  "---"
+  "----"
+] @punctuation.special
+  (#set! priority 95))
+
+[
+  (binary_change)
+  (similarity)
+  (file_change)
+] @label
+
+(index
+  "index" @keyword)
+
+(similarity
+  (score) @number
+  "%" @number)


### PR DESCRIPTION
Add comprehensive syntax highlighting rules for diff file parsing using TreeSitter. This new highlights query file provides proper coloring and semantic highlighting for various diff elements including:

- Comments and spell-check support
- Addition/deletion indicators with diff-specific highlight groups
- Commit hashes and file metadata
- Command and argument highlighting
- Special punctuation for diff markers with priority override
- File paths and mode numbers with appropriate highlight groups

This ensures diff files are properly highlighted in Neovim with TreeSitter parser.